### PR TITLE
PS/2 Kbd MURMULATOR Fix

### DIFF
--- a/src/hdmi/main.cpp
+++ b/src/hdmi/main.cpp
@@ -170,7 +170,7 @@ void __not_in_flash_func(process_picomputer_kbd_report)(hid_keyboard_report_t co
 #ifdef USE_MRMLTR_PS2_KBD
 static Ps2Kbd_Mrmltr ps2kbd(
   pio1,
-  8,
+  0,
   process_kbd_report
 );
 #elif defined(USE_PS2_KBD)

--- a/src/vga/main.cpp
+++ b/src/vga/main.cpp
@@ -122,7 +122,7 @@ extern "C"  void __not_in_flash_func(process_kbd_report)(hid_keyboard_report_t c
 #ifdef USE_MRMLTR_PS2_KBD
 static Ps2Kbd_Mrmltr ps2kbd(
   pio1,
-  8,
+  0,
   process_kbd_report
 );
 #elif defined(USE_PS2_KBD)


### PR DESCRIPTION
The latest builds for MURMULATOR in the UF2 folder contain a non-working PS2 keyboard.
The MURMULATOR platform is also developing and it has I2S sound, which can also be added to the build options.
A big thank you for your work from our community.

![Murmulator1+TFT+NES+I2C_Wii+I2S_DAC+PSRAM](https://github.com/fruit-bat/pico-zxspectrum/assets/68352140/2c0d27ba-fb9a-45fc-a0f1-26b671ccd856)