### PR TITLE
Removes the need to board type

### DIFF
--- a/src/hdmi/CMakeLists.txt
+++ b/src/hdmi/CMakeLists.txt
@@ -319,6 +319,10 @@ set(zx_spectrum_adafuit_feather_hdmi_defines
   SDCARD_PIN_SPI0_MISO=12
   # Speaker pin audio
   SPK_PIN=25
+  # defines from the board type
+  PICO_BOOT_STAGE2_CHOOSE_GENERIC_03H=1
+  PICO_FLASH_SPI_CLKDIV=4
+  PICO_RP2040_B0_SUPPORTED=0
 )
 
 target_compile_definitions(ZxSpectrumAdafruitFeatherHdmi PRIVATE


### PR DESCRIPTION
Moved some of the defines into the CMakeList file so there's no need for the board type.

Part of #147 